### PR TITLE
Add the ability to use triggers and provisioners

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,21 +1,42 @@
 require 'vagrant-bolt'
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
-  config.ssh.insert_key = false
+  config.ssh.insert_key  = false
   config.bolt.run_as    = 'root'
-  config.vm.define 'server' do |s|
-    s.vm.provision :bolt do |bolt|
-      bolt.task         = "facts::bash"
+
+  # Using a global bolt trigger for a plan
+  # This will fire on all machines after :up
+  config.trigger.after :up do |trigger|
+    trigger.name = "Bolt \"facts::bash\" after :up"
+    trigger.ruby do |env, machine|
+      VagrantBolt.plan("facts", env, machine)
     end
   end
-  config.vm.define 'server2' do |s|
-    s.vm.provision :bolt do |bolt|
-      bolt.task         = "facts::bash"
+
+  ## Server
+  config.vm.define 'server' do |server|
+    # Machine level bolt configs
+    server.bolt.run_as   = 'vagrant'
+    # Trigger bolt using a trigger
+    server.trigger.after :provision do |trigger|
+      trigger.name = "Bolt \"facts::bash\" after provision"
+      trigger.ruby do |env, machine|
+        # Sending additional config for the task
+        VagrantBolt.task("facts::bash", env, machine)
+      end
     end
-    s.vm.provision :bolt do |bolt|
-      bolt.task         = "service::linux"
-      bolt.parameters   = {name: "cron", action: "restart"}
+  end
+
+  ## Server2
+  config.vm.define 'server2' do |server2|
+
+    # Using the Bolt provisioner instead of a trigger
+    server2.vm.provision :bolt do |bolt|
+      bolt.type         = :task
+      bolt.name         = "service::linux"
+      bolt.parameters   = { name: "cron", action: "restart"}
       bolt.nodes        = 'ALL'
+      bolt.run_as       = "root"
     end
   end
 end

--- a/lib/vagrant-bolt.rb
+++ b/lib/vagrant-bolt.rb
@@ -1,7 +1,27 @@
 module VagrantBolt
   require 'vagrant-bolt/version'
   require 'vagrant-bolt/plugin'
-  require 'pry' #REMOVEME
+  require 'vagrant-bolt/runner'
+
+  # Run a bolt task
+  # @param [String] task The name of the bolt task to run
+  # @param [Object] env The environment
+  # @param [Object] machine The machine
+  # @param [Array[Hash], nil] args A optional hash of bolt config overrides; {run_as: "root", parameters: {taskparam: "value"}}
+  def self.task(task, env, machine, *args)
+    runner = VagrantBolt::Runner.new(env, machine)
+    runner.run(:task, task, *args)
+  end
+
+  # Run a bolt plan
+  # @param [String] plan The name of the bolt plan to run
+  # @param [Object] env The environment
+  # @param [Object] machine The machine
+  # @param [Array[Hash], nil] args A optional hash of bolt config overrides; {run_as: "root", parameters: {planparam: "value"}}
+  def self.plan(plan, env, machine, *args)
+    runner = VagrantBolt::Runner.new(env, machine)
+    runner.run(:plan, plan, *args)
+  end
 
   def self.source_root
     @source_root ||= File.expand_path('..', __FILE__)

--- a/lib/vagrant-bolt/config/bolt.rb
+++ b/lib/vagrant-bolt/config/bolt.rb
@@ -1,12 +1,12 @@
 class VagrantBolt::Config::Bolt < Vagrant.plugin('2', :config)
 
-  # @!attribute [rw] task
-  #   @return [String] The name of task to run
-  attr_accessor :task
+  # @!attribute [rw] name
+  #   @return [String] The name of task or plan to run
+  attr_accessor :name
 
-  # @!attribute [rw] plan
-  #   @return [String] The name of plan to run
-  attr_accessor :plan
+  # @!attribute [rw] type
+  #   @return [Symbol] Task or Plan
+  attr_accessor :type
 
   # @!attribute [rw] parameters
   #   @return [Hash] The paramater hash for the task or plan
@@ -72,13 +72,13 @@ class VagrantBolt::Config::Bolt < Vagrant.plugin('2', :config)
   #   @return [String] 	User to run as using privilege escalation.
   attr_accessor :run_as
 
-  # @!attribute [rw] deploypuppetfile
-  #   @return [Boolean] 	If the `boltdir/Puppetfile` should be deployed. Note that this setting is global for all provisioners.
-  attr_accessor :deploypuppetfile
+  # @!attribute [rw] args
+  #   @return [String] 	Additional arguments for the bolt command
+  attr_accessor :args
 
   def initialize
-    @task             = UNSET_VALUE
-    @plan             = UNSET_VALUE
+    @name             = UNSET_VALUE
+    @type             = UNSET_VALUE
     @parameters       = UNSET_VALUE
     @nodes            = UNSET_VALUE
     @username         = UNSET_VALUE
@@ -95,12 +95,12 @@ class VagrantBolt::Config::Bolt < Vagrant.plugin('2', :config)
     @boltcommand      = UNSET_VALUE
     @boltdir          = UNSET_VALUE
     @run_as           = UNSET_VALUE
-    @deploypuppetfile = UNSET_VALUE
+    @args             = UNSET_VALUE
   end
 
   def finalize!
-    @task             = nil if @task == UNSET_VALUE
-    @plan             = nil if @plan == UNSET_VALUE
+    @name             = nil if @name == UNSET_VALUE
+    @type             = nil if @type == UNSET_VALUE
     @parameters       = nil if @parameters == UNSET_VALUE
     @nodes            = nil if @nodes == UNSET_VALUE
     @username         = nil if @username == UNSET_VALUE
@@ -117,19 +117,19 @@ class VagrantBolt::Config::Bolt < Vagrant.plugin('2', :config)
     @boltcommand      = 'bolt' if @boltcommand == UNSET_VALUE
     @boltdir          = '.' if @boltdir == UNSET_VALUE
     @run_as           = nil if @run_as == UNSET_VALUE
-    @deploypuppetfile = true if @deploypuppetfile == UNSET_VALUE
+    @args             = nil if @args == UNSET_VALUE
   end
 
   def validate(machine)
     errors = _detected_errors
     # if @task.nil? && @plan.nil?
     #   errors << I18n.t('vagrant-bolt.config.bolt.errors.no_task_or_plan')
-    if !@task.nil? && !@plan.nil?
-      errors << I18n.t('vagrant-bolt.config.bolt.errors.task_and_plan_configured',
-                        :task => @task,
-                        :plan => @plan,
-                      )
-    end
+    # if !@name.nil?
+    #   errors << I18n.t('vagrant-bolt.config.bolt.errors.task_and_plan_configured',
+    #                     :task => @task,
+    #                     :plan => @plan,
+    #                   )
+    # end
 
     {"Bolt" => errors }
   end

--- a/lib/vagrant-bolt/plugin.rb
+++ b/lib/vagrant-bolt/plugin.rb
@@ -1,8 +1,8 @@
 require 'vagrant'
 require 'vagrant-bolt/version'
 
-if Vagrant::VERSION < "2.1.0"
-      raise "vagrant-bolt version #{VagrantBolt::VERSION} requires Vagrant 2.1 or later"
+if Vagrant::VERSION < "2.2.0"
+      raise "vagrant-bolt version #{VagrantBolt::VERSION} requires Vagrant 2.2 or later"
 end
 
 class VagrantBolt::Plugin < Vagrant.plugin('2')

--- a/lib/vagrant-bolt/provisioner/bolt.rb
+++ b/lib/vagrant-bolt/provisioner/bolt.rb
@@ -1,5 +1,6 @@
 require 'vagrant'
 require 'vagrant/errors'
+require 'vagrant-bolt/util'
 
 class VagrantBolt::Provisioner::Bolt < Vagrant.plugin('2', :provisioner)
   # Provision VMs with Bolt
@@ -7,16 +8,12 @@ class VagrantBolt::Provisioner::Bolt < Vagrant.plugin('2', :provisioner)
 
   def configure(root_config)
     merge_root_config(root_config.bolt)
-    #TODO: Check for bolt command, etc
-    ## triggers need the machine booted, or ruby code in vagrant 2.2.0 to work in configure
-    # add_bolt_trigger
   end
 
   def provision
-    setup_overrides
-    # Use an execute locally for now
-    deploy_puppetfile if config.deploypuppetfile
-    run_bolt
+    runner = VagrantBolt::Runner.new(@machine.env, @machine, @config)
+    #TODO: validate_config for type and name
+    runner.run(@config.type, @config.name)
   end
 
   def cleanup
@@ -24,6 +21,8 @@ class VagrantBolt::Provisioner::Bolt < Vagrant.plugin('2', :provisioner)
   end
 
   private
+
+  include VagrantBolt::Util
 
   # Merge the local and root_config settings into @config
   # Allow for setting defaults in the root_config. We merge them here.
@@ -34,168 +33,5 @@ class VagrantBolt::Provisioner::Bolt < Vagrant.plugin('2', :provisioner)
     result = merge_config(result, config)
     result.finalize!
     @config = result
-  end
-
-  # Since the configs have been finalized they will have `nil` values
-  # instead of UNSET_VALUE
-  # Merge two config objects overwriting nil objects
-  # @param [Object] local The local config object
-  # @param [Object] other The other config object
-  # @return [Object] a merged result with local overriding other
-  def merge_config(local, other)
-    result = local.class.new
-    [local, other].each do |obj|
-      obj.instance_variables.each do |key|
-        value = obj.instance_variable_get(key)
-        result.instance_variable_set(key, value) if value != Vagrant::Plugin::V2::Config::UNSET_VALUE and value != nil
-      end
-    end
-    return result
-  end
-
-  # Set up some connection defaults for connecting to the machine if values are not set
-  def setup_overrides
-    config.nodes = all_node_list(machine.env) if config.nodes == "ALL"
-    ssh_info = @machine.ssh_info
-    raise Vagrant::Errors::SSHNotReady if ssh_info.nil?
-    config.nodes ||= "#{ssh_info[:host]}:#{ssh_info[:port]}"
-    config.username ||= ssh_info[:username]
-    config.privatekey ||= ssh_info[:private_key_path][0]
-    config.hostkeycheck ||= ssh_info[:verify_host_key]
-  end
-
-  # Create a bolt command from the config
-  # @return [String] The bolt command
-  def create_command
-    #TODO: add the rest of the options
-    command = []
-    command << config.boltcommand
-    plan_or_task = config.task.nil? ? "plan run #{config.plan}" : "task run #{config.task}"
-    command << plan_or_task
-    command << "-u #{config.username}" unless config.username.nil?
-    command << "--private-key #{config.privatekey}" unless config.privatekey.nil?
-    host_key_check = (config.hostkeycheck == true) ? "--host-key-check" : "--no-host-key-check"
-    command << host_key_check
-    command << "--modulepath #{config.modulepath}"
-    command << "-n #{config.nodes}"
-    command << "--params \'#{config.parameters.to_json}\'" unless config.parameters.nil?
-    command << "--run_as #{config.run_as}" unless config.run_as.nil?
-    command.flatten.join(" ")
-  end
-
-  # Run bolt locally with an execute
-  def run_bolt
-    command = create_command
-    machine.ui.info(
-      I18n.t('vagrant-bolt.provisioner.bolt.info.running_bolt',
-        :command => command,
-        ))
-    result = Vagrant::Util::Subprocess.execute(
-        'bash',
-        '-c',
-        command,
-        :notify => [:stdout, :stderr],
-        :env => {PATH: ENV["VAGRANT_OLD_ENV_PATH"]},
-      ) do |io_name, data|
-          @machine.env.ui.info "[#{io_name}] #{data}"
-        end
-  end
-
-  # Deploy the Puppetfile if it exists
-  def deploy_puppetfile
-    ## TODO: Convert this to a trigger that only runs once pre provision
-    ## Currently it runs on the first configure
-    ######## Does not fire the root or before trigger from this scope ########
-    # if File.file?("#{config.boltdir}/Puppetfile")
-    #   existing_trigger = machine.config.trigger.before_triggers.find { |t| t.name = "Deploying Puppetfile" }
-    #   unless existing_trigger
-    #     command = "#{config.boltcommand} puppetfile install --boltdir #{config.boltdir}"
-    #     options = {
-    #       name: "Deploying Puppetfile",
-    #       run:  {
-    #         inline: command
-    #       }
-    #     }
-    #     trigger = generate_trigger(:provision, options)
-    #     ##root_config.trigger.before_triggers << trigger
-    #     machine.config.trigger.before_triggers << trigger
-    #
-    # end
-    # else
-    #   # "No Puppetfile exists; not updating"
-    # end
-    ######## End ########
-    
-    # Use an execute instead, but only do it once and update the root_config
-    if File.file?("#{config.boltdir}/Puppetfile") #and root_config.bolt.deploypuppetfile
-      machine.ui.info(I18n.t('vagrant-bolt.provisioner.bolt.info.deploying_puppetfile'))
-      command = "#{config.boltcommand} puppetfile install --boltdir #{config.boltdir}"
-      result = Vagrant::Util::Subprocess.execute(
-          'bash',
-          '-c',
-          command,
-          :notify => [:stdout, :stderr],
-          :env => {PATH: ENV["VAGRANT_OLD_ENV_PATH"]},
-        ) do |io_name, data|
-          @machine.env.ui.info "[#{io_name}] #{data}"
-        end
-        #root_config.bolt.set_options({:deploypuppetfile => false})
-    end
-  end
-
-  # Add a bolt trigger to the machine after provision triggers
-  def add_bolt_trigger
-    machine.ui.info(
-      I18n.t('vagrant-bolt.provisioner.bolt.info.adding_trigger',
-        :action => ":provision",
-        :machine => machine.name,
-        ))
-    command = create_command
-    options = map_trigger_options(command)
-    trigger = generate_trigger(:provision, options)
-    machine.config.trigger.after_triggers << trigger
-  end
-
-  # Generate a trigger Object
-  # @param [Symbol] action the action to generate the trigger on
-  # @param [Hash] options a hash of VagrantPlugins::Kernel_V2::VagrantConfigTrigger options
-  # @return [Object] finalized VagrantPlugins::Kernel_V2::VagrantConfigTrigger object
-  def generate_trigger(action, options)
-    trigger = VagrantPlugins::Kernel_V2::VagrantConfigTrigger.new(action)
-    trigger.set_options(options)
-    trigger.finalize!
-    return trigger
-  end
-
-  # Create a hash of options for a trigger object
-  # @param [String] command The command to be passed to the inline run
-  # @return [Hash]
-  def map_trigger_options(command)
-    options = {}
-    options[:name] = "Bolt #{config.task}"
-    options[:run] = {inline: command}
-    return options
-  end
-
-  # Generate a CSV list of node:port addresses for all active nodes in the environment
-  # @param [Object] env The Enviornment
-  # @return [String]
-  def all_node_list(env)
-    nodes_in_environment(env).map { |vm|
-      "#{vm.ssh_info[:host]}:#{vm.ssh_info[:port]}" unless vm.ssh_info.nil?
-    }.compact.join(",")
-  end
-
-  # Generate a list of active machines in the environment
-  # @param [Object] env The Environment
-  # @return [Array[Object]]
-  def nodes_in_environment(env)
-    env.active_machines.map { |vm|
-      begin
-        env.machine(*vm)
-      rescue Vagrant::Errors::MachineNotFound
-        nil
-      end
-    }.compact
   end
 end

--- a/lib/vagrant-bolt/runner.rb
+++ b/lib/vagrant-bolt/runner.rb
@@ -1,0 +1,100 @@
+require 'vagrant-bolt/util'
+
+class VagrantBolt::Runner
+
+  def initialize(env, machine, boltconfig = nil)
+    @env = env
+    @machine = machine
+    @boltconfig = boltconfig.nil? ? machine.config.bolt : boltconfig
+  end
+
+  # Run a bolt task or plan
+  # @param [Symbol|String] type The type of bolt to run; task or plan
+  # @param [String] name The name of the bolt task or plan to run
+  # @param [Array[Hash], nil] args A optional hash of bolt config overrides; {run_as: "vagrant"}
+  def run(type, name, *args)
+    @boltconfig = setup_overrides(type, name, *args)
+    run_bolt
+  end
+
+  private
+
+  include VagrantBolt::Util
+
+  # Set up config overrides
+  # @param [Symbol|String] type The type of bolt to run; task or plan
+  # @param [String] name The name of the bolt task or plan to run
+  # @param [Array[Hash], nil] args A optional hash of bolt config overrides; {run_as: "vagrant"}
+  # @return [Object] Bolt config with ssh info populated
+  def setup_overrides(type, name, *args)
+    #config = @boltconfig.merge(@machine.config.bolt)
+    config = @boltconfig.dup
+    config.type = type
+    config.name = name
+    # Add any additional arguments to the config object
+    args.each do |arg|
+      config.set_options(arg)
+    end
+
+    # Pupulate ssh_info
+    config.nodes = all_node_list(@env) if config.nodes.to_s.downcase == "all"
+    ssh_info = @machine.ssh_info
+    raise Vagrant::Errors::SSHNotReady if ssh_info.nil?
+    config.nodes ||= "#{ssh_info[:host]}:#{ssh_info[:port]}"
+    config.username ||= ssh_info[:username]
+    config.privatekey ||= ssh_info[:private_key_path][0]
+    config.hostkeycheck ||= ssh_info[:verify_host_key]
+    return config
+  end
+
+  # Run bolt locally with an execute
+  def run_bolt
+    command = create_command
+    @machine.ui.info(
+      I18n.t('vagrant-bolt.provisioner.bolt.info.running_bolt',
+        :command => command,
+        ))
+    result = Vagrant::Util::Subprocess.execute(
+        'bash',
+        '-c',
+        command,
+        :notify => [:stdout, :stderr],
+        :env => {PATH: ENV["VAGRANT_OLD_ENV_PATH"]},
+      ) do |io_name, data|
+          @machine.ui.info "[#{io_name}] #{data}"
+        end
+  end
+
+  # Create a bolt command from the config
+  # @return [String] The bolt command
+  def create_command
+    #TODO: add all of the bolt the options and account for Windows Guests
+    command = []
+    command << @boltconfig.boltcommand
+    command << "#{@boltconfig.type.to_s} run #{@boltconfig.name}"
+    command << "-u #{@boltconfig.username}" unless @boltconfig.username.nil?
+
+    # Windows and Linux specific items (This is for the agent side, so it doesn't fully make sense)
+    if Vagrant::Util::Platform.windows?
+      ssl = (@boltconfig.ssl == true) ? "--ssl" : "--no-ssl"
+      command << ssl
+      sslverify = (@boltconfig.sslverify == true) ? "--ssl-verify" : "--no-ssl-verify"
+      command << sslverify
+    else
+      command << "--private-key #{@boltconfig.privatekey}" unless @boltconfig.privatekey.nil?
+      host_key_check = (@boltconfig.hostkeycheck == true) ? "--host-key-check" : "--no-host-key-check"
+      command << host_key_check
+      command << "--sudo-password \'#{@boltconfig.sudopassword}\'" unless @boltconfig.sudopassword.nil?
+
+    end
+
+    command << "--run_as #{@boltconfig.run_as}" unless @boltconfig.run_as.nil?
+    command << "--modulepath #{@boltconfig.modulepath}"
+    command << "-n #{@boltconfig.nodes}"
+    command << "--params \'#{@boltconfig.parameters.to_json}\'" unless @boltconfig.parameters.nil?
+    command << "--verbose" if @boltconfig.verbose
+    command << "--debug" if @boltconfig.debug
+    command << @boltconfig.args unless @boltconfig.args.nil?
+    command.flatten.join(" ")
+  end
+end

--- a/lib/vagrant-bolt/util.rb
+++ b/lib/vagrant-bolt/util.rb
@@ -1,0 +1,45 @@
+module VagrantBolt::Util
+  # Utility Functions
+
+  # Merge config objects overriding Nil and UNSET_VALUE
+  # Since the configs have been finalized they will have `nil` values
+  # instead of UNSET_VALUE
+  # @param [Object] local The local config object
+  # @param [Object] other The other config object
+  # @return [Object] a merged result with local overriding other
+  def merge_config(local, other)
+    result = local.class.new
+    [local, other].each do |obj|
+      obj.instance_variables.each do |key|
+        value = obj.instance_variable_get(key)
+        result.instance_variable_set(key, value) if value != Vagrant::Plugin::V2::Config::UNSET_VALUE and value != nil
+      end
+    end
+    return result
+  end
+
+  # Generate a list of active machines in the environment
+  # @param [Object] env The Environment
+  # @return [Array[Object]]
+  def nodes_in_environment(env)
+    env.active_machines.map { |vm|
+      begin
+        env.machine(*vm)
+      rescue Vagrant::Errors::MachineNotFound
+        nil
+      end
+    }.compact
+  end
+
+  # Generate a CSV list of node:port addresses for all active nodes in the environment
+  # @param [Object] env The Enviornment
+  # @param [Array[String]] excludes Array of machine names to exclude
+  # @return [String]
+  def all_node_list(env, excludes = [])
+    nodes_in_environment(env).map { |vm|
+      unless excludes.include?(vm.name.to_s)
+        "#{vm.ssh_info[:host]}:#{vm.ssh_info[:port]}" unless vm.ssh_info.nil?
+      end
+    }.compact.join(",")
+  end
+end


### PR DESCRIPTION
This commit adds the ability to use bolt tasks and plans in triggers as
well as a provisioner. The triggers require Vagrant 2.2.0 to leverage
the Ruby block. The provisioner and triggers now share the same back end
code.