### PR TITLE
(SUP-874) Add a command line interface

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -102,6 +102,8 @@ Metrics/MethodLength:
     - validate
 Metrics/ClassLength:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Style/StringLiterals:
   Enabled: false
 Naming/FileName:

--- a/README.md
+++ b/README.md
@@ -316,6 +316,40 @@ vms:
   - name: server
 ~~~
 
+Commands
+--------
+Vagrant bolt comes with a single command that helps to run ad-hoc bolt commands. The `vagrant bolt` command is available to run bolt commands locally using the inventory file for the vagrant machines. 
+
+The format of the command is below. 
+
+~~~
+Usage: vagrant bolt <options> [bolt options]
+
+Options:
+
+    -u, --[no-]updateinventory       Update the inventory file (defaults to false)
+~~~
+
+The command can be used to deploy the Puppetfile, for example. 
+
+~~~
+vagrant bolt puppetfile install
+~~~
+
+It can be used to run ad-hoc tasks on a node by specifying the node by its machine name.
+
+~~~
+vagrant bolt -u task run facts -n server
+~~~
+
+The `--updateinventory` flag will regenerate the inventory file from the active running machines, however it defaults to being off. In the example above, the inventory file will be updated prior to running the task.
+
+All parameters execpt for the `-u` will be passed to bolt, so a bolt command like the exaple below can be run. 
+
+~~~
+vagrant bolt command run 'date' -n agent,master
+~~~
+
 Installation
 ------------
 

--- a/lib/vagrant-bolt/plugin.rb
+++ b/lib/vagrant-bolt/plugin.rb
@@ -27,6 +27,11 @@ class VagrantBolt::Plugin < Vagrant.plugin('2')
     VagrantBolt::Provisioner
   end
 
+  command(:bolt) do
+    require_relative 'command'
+    VagrantBolt::Command
+  end
+
   def self.config_builder_hook
     require_relative 'config_builder'
   end

--- a/spec/unit/runner/runner_spec.rb
+++ b/spec/unit/runner/runner_spec.rb
@@ -88,26 +88,8 @@ describe VagrantBolt::Runner do
     end
   end
 
-  context 'run_bolt' do
-    let(:options) { { notify: [:stdout, :stderr], env: { PATH: nil } } }
-    before(:each) do
-      allow(Vagrant::Util::Subprocess).to receive(:execute).and_return(subprocess_result)
-    end
-    it 'creates a shell execution' do
-      config.type = 'task'
-      config.name = 'foo'
-      config.bolt_command = 'bolt'
-      config.modulepath = 'modules'
-      config.boltdir = '.'
-      config.node_list = 'ssh://test:22'
-      config.finalize!
-      command = "bolt task run 'foo' --modulepath '#{root_path}/modules' --boltdir '#{root_path}/.' --inventoryfile '#{local_data_path}/bolt_inventory.yaml' -n 'ssh://test:22'"
-      expect(Vagrant::Util::Subprocess).to receive(:execute).with('bash', '-c', command, options).and_return(subprocess_result)
-      subject.send(:run_bolt)
-    end
-  end
-
   context 'run' do
+    let(:options) { { notify: [:stdout, :stderr], env: { PATH: nil } } }
     before(:each) do
       allow(Vagrant::Util::Subprocess).to receive(:execute).and_return(subprocess_result)
       allow_any_instance_of(VagrantBolt::Util).to receive(:update_inventory_file).and_return("#{local_data_path}/bolt_inventory.yaml")
@@ -123,6 +105,17 @@ describe VagrantBolt::Runner do
 
     it 'raises an exception if the name is not specified' do
       expect { subject.run('task', nil) }.to raise_error(Vagrant::Errors::ConfigInvalid, %r{No name set})
+    end
+
+    it 'creates a shell execution' do
+      config.bolt_command = 'bolt'
+      config.modulepath = 'modules'
+      config.boltdir = '.'
+      config.node_list = 'ssh://test:22'
+      config.finalize!
+      command = "bolt task run 'foo' --modulepath '#{root_path}/modules' --boltdir '#{root_path}/.' --inventoryfile '#{local_data_path}/bolt_inventory.yaml' -n 'ssh://test:22'"
+      expect(Vagrant::Util::Subprocess).to receive(:execute).with('bash', '-c', command, options).and_return(subprocess_result)
+      subject.run('task', 'foo')
     end
   end
 end


### PR DESCRIPTION
This PR adds the `vagrant bolt` command to the plugin. It enables running commands using the configured inventory, modulepath, and boltdir. It has the ability to update the inventory when specified.